### PR TITLE
#164734798 Account transaction history page design

### DIFF
--- a/ui/css/style.css
+++ b/ui/css/style.css
@@ -358,6 +358,7 @@ input {
 	text-align: left;
 }
 
+.transac-history table thead tr th,
 .transac-history table tbody tr td {
 	text-align: center;
 }
@@ -366,7 +367,7 @@ input {
 	border: none;
 	padding: 0.312rem 0.625rem;
 	border-radius: 0.312rem;
-	transition: all 500ms ease-in-out;
+	transition: all 250ms ease-in-out;
 	background-color: var(--june-bud);
 }
 

--- a/ui/udashboard.html
+++ b/ui/udashboard.html
@@ -78,7 +78,7 @@
                 </div>
 								<div class="summary-listing">
 									<h4>Balance (NGN):</h4>
-									<p>0<sup>.00</sup></p>
+									<p>4,000.00</p>
 								</div>
 							</div>
               <div class="transac-history">
@@ -98,16 +98,16 @@
                     <tr>
                       <td>1</td>
                       <td>Credit</td>
-                      <td>5000.00</td>
-                      <td>5000.00</td>
+                      <td>5,000.00</td>
+                      <td>5,000.00</td>
                       <td>27/3/2019</td>
                       <td><button>View details</button></td>
                     </tr>
                     <tr>
                       <td>2</td>
                       <td>Debit</td>
-                      <td>1000.00</td>
-                      <td>4000.00</td>
+                      <td>1,000.00</td>
+                      <td>4,000.00</td>
                       <td>28/3/2019</td>
                       <td><button>View details</button></td>
                     </tr>


### PR DESCRIPTION
Account transaction history design.

The design was already part of the previous commit  [Feature 164859850] Design user private dashboard. So I made some little changes to have this push as planned out in my PT.

Centered Transaction titles, as well as transaction history contents.
I also increase the transition time from 500ms to 250ms.