### PR TITLE
#165329732 Add endpoint for admin to activate or deactivate an account

### DIFF
--- a/api/controllers/accounts.controller.js
+++ b/api/controllers/accounts.controller.js
@@ -43,7 +43,11 @@ const AccountController = {
 	 */
   patchAnAccount(req, res) {
     const currentUser = req.user;
-    const desiredAccount = AccountService.patchAccount(req.params, currentUser);
+    const { accountNumber } = req.params;
+    if (!accountNumber) {
+      throw 'Account not found';
+    }
+    const desiredAccount = AccountService.patchAccount(req.body, req.params, currentUser);
     res.status(200).json({
       status: 200,
       data: desiredAccount,

--- a/api/models/users.model.js
+++ b/api/models/users.model.js
@@ -1,6 +1,6 @@
 class User {
   /**
-   *
+	 *
 	 * @class constructor
 	 * @param {object} data
 	 */
@@ -10,6 +10,7 @@ class User {
     this.lastName = null;
     this.email = null;
     this.password = null;
+    this.status = null;
     this.type = null;
     this.phoneNumber = null;
     this.address = null;

--- a/api/routes/accounts.route.js
+++ b/api/routes/accounts.route.js
@@ -6,7 +6,12 @@ import AccountController from '../controllers/accounts.controller';
 const router = Router();
 
 router.post('/', authorizeRole(Role.Client), AccountController.createANewAccount);
-router.get('/', AccountController.getAllAccounts);
+router.patch(
+  '/:accountNumber',
+  authorizeRole([Role.Admin, Role.Staff]),
+  AccountController.patchAnAccount,
+);
+router.get('/accounts', AccountController.getAllAccounts);
 router.delete('/:accountNumber', AccountController.deleteAnAccount);
 router.get('/:accountNumber', AccountController.getAnAccountDetails);
 

--- a/api/services/accounts.service.js
+++ b/api/services/accounts.service.js
@@ -1,6 +1,6 @@
-import uuid from 'uuid';
 import moment from 'moment';
 import dummyDB from '../utils/dummyDB';
+import Role from '../Middleware/role';
 import generateAccountNumber from '../Middleware/account-gen';
 
 /**
@@ -69,10 +69,23 @@ const AccountService = {
 	 *
 	 * @returns {object} account object
 	 */
-  patchAccount(data, currentUser) {
-    const account = dummyDB.accounts.find(account => account.accountNumber === data.accountNumber);
+  patchAccount(newStatusInfo, data, currentUser) {
+    const accountToPatch = String(data.accountNumber);
+    const account = dummyDB.accounts.find(account => account.accountNumber === accountToPatch);
+    const userWithRole = dummyDB.users.find(user => user.id === currentUser.sub);
 
-    return account;
+    // only allow Admin and Staff to access access
+    if (userWithRole.id === currentUser.sub && currentUser.role !== Role.Admin) {
+      throw 'Unauthorized';
+    }
+
+    const accountIndex = dummyDB.accounts.indexOf(account);
+    dummyDB.accounts[accountIndex].status = newStatusInfo.status;
+    const newAccountStatus = dummyDB.accounts[accountIndex].status;
+    return {
+      accountNumber: account.accountNumber,
+      status: newAccountStatus,
+    };
   },
   /**
 	 *

--- a/api/utils/dummyDB.js
+++ b/api/utils/dummyDB.js
@@ -48,7 +48,7 @@ export default {
       lastName: 'Targaeryean',
       email: 'd.targaeryean@targearyean.got',
       password: '123456',
-      type: 'staff',
+      type: 'Staff',
       phoneNumber: '08123676589',
       address: {
         street: '122 Westeros Ave.',
@@ -64,7 +64,7 @@ export default {
       lastName: 'Lannister',
       email: 'jamielannister@lannisters.got',
       password: '123456',
-      type: 'staff',
+      type: 'Admin',
       phoneNumber: '08053676589',
       address: {
         street: '122 King Slayer Ave.',


### PR DESCRIPTION
#### What does this PR do?
Add endpoint to create an account

#### Description of Task to be completed?
add patch account controller
add patch account logic
add patch route

#### How should this be manually tested?
Start the server using `npm run start-dev` then 
Login by making a POST request on the route localhost:9000/api/v1/auth/signin using postman.
Extract the token generated from the created account and use it to make a POST request to `localhost:9000/api/v1/account/:accountNumber` with the new status, say:
```
{
   "status": "dormat"
}
```
#### Any background context you want to provide?
Admin after login should be able to either activate or deactivate an account

What are the relevant pivotal tracker stories?
[#165329732](https://www.pivotaltracker.com/story/show/165329732)