### PR TITLE
#165329830 Add functionality to delete an account by an admin

### DIFF
--- a/api/controllers/accounts.controller.js
+++ b/api/controllers/accounts.controller.js
@@ -75,18 +75,21 @@ const AccountController = {
 	 * @returns {void} returns status code 204
 	 */
   deleteAnAccount(req, res) {
+    const currentUser = req.user;
     const { accountNumber } = req.params;
+    if (!accountNumber) {
+      throw 'Account not found';
+    }
     const foundAccount = AccountService.getAnAccount(accountNumber);
     if (!foundAccount) {
       return res.status(404).json({
         status: 404,
-        message: 'User not found',
+        message: 'Account not found',
       });
     }
-    AccountService.deleteAccount(accountNumber);
-    res.status(204).json({
-      status: 204,
-      message: 'User deleted successfully',
+    const deleteMessage = AccountService.deleteAccount(accountNumber, currentUser);
+    res.status(200).json({
+      deleteMessage,
     });
   },
 };

--- a/api/routes/accounts.route.js
+++ b/api/routes/accounts.route.js
@@ -11,8 +11,12 @@ router.patch(
   authorizeRole([Role.Admin, Role.Staff]),
   AccountController.patchAnAccount,
 );
-router.get('/accounts', AccountController.getAllAccounts);
-router.delete('/:accountNumber', AccountController.deleteAnAccount);
-router.get('/:accountNumber', AccountController.getAnAccountDetails);
+router.delete(
+  '/:accountNumber',
+  authorizeRole([Role.Admin, Role.Staff]),
+  AccountController.deleteAnAccount,
+);
+router.get('/accounts', authorizeRole([Role.Admin, Role.Staff]), AccountController.getAllAccounts);
+router.get('/:accountNumber', authorizeRole(), AccountController.getAnAccountDetails);
 
 export default router;

--- a/api/services/accounts.service.js
+++ b/api/services/accounts.service.js
@@ -104,11 +104,22 @@ const AccountService = {
 	 *
 	 * @param {string} accountNumber
 	 */
-  deleteAccount(accountNumber) {
-    const account = dummyDB.accounts.map(account => account.accountNumber === accountNumber);
+  deleteAccount(accountNumber, currentUser) {
+    const accountToDelete = String(accountNumber);
+    const account = dummyDB.accounts.find(account => account.accountNumber === accountToDelete);
+    const userWithRole = dummyDB.users.find(user => user.id === currentUser.sub);
     const accountIndex = dummyDB.accounts.indexOf(account);
+
+    // only allow Admin and Staff to access access
+    if (userWithRole.id === currentUser.sub && currentUser.role !== Role.Admin) {
+      throw 'Unauthorized';
+    }
+
     dummyDB.accounts.splice(accountIndex, 1);
-    return {};
+    return {
+      status: 204,
+      message: 'Account successfully deleted',
+    };
   },
 };
 


### PR DESCRIPTION
#### What does this PR do?
Add account delete route

#### Description of Task to be completed?
add endpoint to delete an account by an admin
add delete account controller
add logic to delete an account
add delete account route

#### How should this be manually tested?
Start the server using `npm run start-dev`
Then login with an admin credentials 
```
"email": "jamielannister@lannisters.got"
"password": "123456"
```
Then use the token return as an `header` for an access to delete an account.
Send a POST request to `localhost:9000/api/v1/accounts/430287547`

#### Any background context you want to provide?
Admin should be able to delete an account

#### What are the relevant pivotal tracker stories?
[Finishes #165329830](https://www.pivotaltracker.com/story/show/165329830)