### PR TITLE
 #165164211 Add endpoint functionality to debit account

### DIFF
--- a/api/controllers/transactions.controller.js
+++ b/api/controllers/transactions.controller.js
@@ -1,0 +1,51 @@
+import TransactionService from '../services/transactions.service';
+import AccountService from '../services/accounts.service';
+
+/**
+ * @TransactionController
+ */
+
+const TransactionController = {
+  /**
+	 *
+	 * @param {object} req
+	 * @param {object} res
+	 *
+	 * @returns {object} transaction object
+	 */
+  debitAnAccount(req, res) {
+    const currentUser = req.user;
+    const { accountNumber } = req.params;
+    const { amount } = req.body;
+    const accountToDebit = AccountService.getAnAccount(accountNumber);
+    if (!accountToDebit) {
+      throw 'Account not found';
+    }
+    const debitTransaction = TransactionService.debitTransaction(
+      accountToDebit,
+      parseFloat(amount).toFixed(2),
+      currentUser,
+    );
+    res.status(201).json({
+      status: 201,
+      data: debitTransaction,
+    });
+  },
+  /**
+	 *
+	 * @param {object} req
+	 * @param {object} res
+	 *
+	 * @returns {object} transaction object
+	 */
+  retrieveAllTransactions(req, res) {
+    const currentUser = req.user;
+    const allExistingTransactions = TransactionService.getAllTransactions(currentUser);
+    res.status(200).json({
+      status: 200,
+      data: allExistingTransactions,
+    });
+  },
+};
+
+export default TransactionController;

--- a/api/index.js
+++ b/api/index.js
@@ -4,6 +4,7 @@ import cors from 'cors';
 import bodyParser from 'body-parser';
 import userRoutes from './routes/users.route';
 import accountRoutes from './routes/accounts.route';
+import transactionRoutes from './routes/transactions.route';
 import errorHandler from './Middleware/error-handler';
 
 // Initializing express and declaring port
@@ -26,6 +27,7 @@ const API_BASE_URL = '/api/v1';
 // Defining all routes
 app.use(`${API_BASE_URL}`, userRoutes);
 app.use(`${API_BASE_URL}/accounts`, accountRoutes);
+app.use(`${API_BASE_URL}/transactions`, transactionRoutes);
 
 app.get('/', (req, res) => {
   res.status(200).json({

--- a/api/models/transactions.model.js
+++ b/api/models/transactions.model.js
@@ -1,0 +1,19 @@
+class Transaction {
+  /**
+	 * @class constructor
+	 * @param {object} data
+	 *
+	 */
+  constructor() {
+    this.id = null;
+    this.createdOn = null;
+    this.transactionType = null; // credit or debit
+    this.accountNumber = null;
+    this.cashier = null; // cashier (staff) who consummated the transaction
+    this.amount = null;
+    this.oldBalance = null;
+    this.newBalance = null;
+  }
+}
+
+export default Transaction;

--- a/api/routes/transactions.route.js
+++ b/api/routes/transactions.route.js
@@ -1,0 +1,24 @@
+import { Router } from 'express';
+import authorizeRole from '../Middleware/authorize-role';
+import Role from '../Middleware/role';
+import TransactionController from '../controllers/transactions.controller';
+
+const router = Router();
+
+router.post(
+  '/:accountNumber/debit',
+  authorizeRole(Role.Staff),
+  TransactionController.debitAnAccount,
+);
+router.get(
+  '/',
+  authorizeRole([Role.Admin, Role.Staff]),
+  TransactionController.retrieveAllTransactions,
+);
+// router.post(
+//   '/:accountNumber/credit',
+//   authorizeRole(Role.Staff),
+//   TransactionController.creditAnAccount,
+// );
+
+export default router;

--- a/api/services/transactions.service.js
+++ b/api/services/transactions.service.js
@@ -1,0 +1,80 @@
+import moment from 'moment';
+import dummyDB from '../utils/dummyDB';
+import Role from '../Middleware/role';
+
+/**
+ * @TransactionService
+ */
+const TransactionService = {
+  /**
+	 * @param {object} account Number object
+	 * @param {object} amount to debit
+	 * @param {object} current user with token
+	 *
+	 * @returns {object} Debit transaction object
+	 */
+  debitTransaction(accountToDebit, amount, currentUser) {
+    const userWithRole = dummyDB.users.find(user => user.id === currentUser.sub);
+
+    // Check rights
+    if (userWithRole.id === currentUser.sub && currentUser.role !== Role.Staff) {
+      throw 'Unauthorized';
+    }
+
+    // Check account balance
+    if (accountToDebit.balance < amount) {
+      throw 'Insufficient account balance';
+    }
+
+    // perform debit operation
+    const returningBalance =			parseFloat(accountToDebit.balance).toFixed(2) - parseFloat(amount).toFixed(2);
+
+    // Generate a new transaction id
+    const transactionLength = dummyDB.transactions.length;
+    const lastTransactionId = dummyDB.transactions[transactionLength - 1].id;
+    const newTransactionId = lastTransactionId + 1;
+
+    // create a new transaction object
+    const newTransaction = {
+      id: newTransactionId,
+      createdOn: moment().format(),
+      transactionType: 'debit',
+      accountNumber: accountToDebit.accountNumber,
+      cashier: currentUser.sub,
+      amount,
+      oldBalance: parseFloat(accountToDebit.balance).toFixed(2),
+      newBalance: parseFloat(returningBalance).toFixed(2),
+    };
+    dummyDB.transactions.push(newTransaction);
+    const {
+      id, createdOn, newBalance, ...withOutOldBalance
+    } = newTransaction;
+    return {
+      transactionId: id,
+      ...withOutOldBalance,
+      accountBalance: newTransaction.newBalance,
+    };
+  },
+  /**
+	 * @param {object} account object
+	 * @param {}
+	 *
+	 * @returns {object} Debit transaction object
+	 */
+  getAllTransactions(currentUser) {
+    // Check rights
+    if (userWithRole.id === currentUser.sub && currentUser.role === Role.Client) {
+      throw 'Unauthorized';
+    }
+    const allTransactions = dummyDB.transactions.map((transaction) => {
+      const { newBalance, oldBalance, ...transactionWithoutNewBalance } = transaction;
+      return transactionWithoutNewBalance;
+    });
+    return {
+      balance: allTransactions.newBalance,
+      ...transactionWithoutNewBalance,
+    };
+  },
+};
+
+export default TransactionService;

--- a/api/utils/dummyDB.js
+++ b/api/utils/dummyDB.js
@@ -1,4 +1,5 @@
 import moment from 'moment';
+import uuid from 'uuid';
 
 /**
  *
@@ -86,7 +87,7 @@ export default {
       owner: '053d71de-707a-4a16-945d-a5255245d64a',
       type: 'savings',
       status: 'active',
-      balance: '500000.00',
+      balance: 300000.00,
     },
     {
       id: '0d4b64b4-c632-497e-b22a-8a6e7694c637',
@@ -95,7 +96,29 @@ export default {
       owner: 'fa77a5a0-d7ac-4870-a7cc-6c7a7df93d5b',
       type: 'current',
       status: 'active',
-      balance: '5000000.00',
+      balance: 300000.00,
+    },
+  ],
+  transactions: [
+    {
+      id: 1,
+      createdOn: moment().format(),
+      transactionType: 'credit',
+      accountNumber: '5789761524',
+      cashier: '209d3dcc-590a-49aa-804e-b0715747252b',
+      amount: 300000.00,
+      oldBalance: 5000000.00,
+      newBalance: 5300000.00,
+    },
+    {
+      id: 2,
+      createdOn: moment().format(),
+      transactionType: 'debit',
+      accountNumber: '430287547',
+      cashier: '209d3dcc-590a-49aa-804e-b0715747252b',
+      amount: 200000.00,
+      oldBalance: 500000.00,
+      newBalance: 300000.00,
     },
   ],
 };

--- a/ui/js/sign-up.js
+++ b/ui/js/sign-up.js
@@ -1,0 +1,12 @@
+const password = document.forms['signup-form'].password.value;
+const confirmPassword = document.forms['signup-form'].confirmPassword.value;
+const submitBtn = document.querySelector('input[type=submit]');
+
+// const submitFormDetails = () => {
+//   location.replace('./udashboard.html');
+//   return false;
+// };
+
+submitBtn.addEventListener('click', () => {
+  location.replace('./udashboard.html');
+});


### PR DESCRIPTION
#### What does this PR do?
Add endpoint functionality for staff to debit an account

#### Description of Task to be completed?
 - add debit transaction controller
 - add debit transaction logic for withdrawing from an account
 - add debit transaction route
 - add dummy transaction data in dummyDB
 - add transaction route to the entry point

#### How should this be manually tested?
Run `npm run start-dev` to start the server.
Login as staff on POSTMAN using the details below:
```
"email": "d.targaeryean@targearyean.got",
"password": "123456"
```
Get token from the login result. Then make a POST request to `localhost:9000/api/v1/transactions/:accountNumber/debit` using the token copied for the staff.

Provide an amount to debit in the form:
```
{
   "amount": 20000.00,
}
```
#### Any background context you want to provide?
Staff should be able to debit an account

#### What are the relevant pivotal tracker stories?
[ #165164211](https://www.pivotaltracker.com/story/show/165164211)